### PR TITLE
Show displayNames when assigning using withProps

### DIFF
--- a/src/createTransformer.ts
+++ b/src/createTransformer.ts
@@ -19,6 +19,9 @@ import {Options} from './models/Options';
  * styledFunction.attrs(attributes)
 */
 function isStyledFunction(node: ts.Node): boolean {
+    if (ts_is_kind_1.isCallExpression(node) && node.arguments.length === 1 && isStyledFunction(node.arguments[0])) {
+       return true;
+    }
     if (isPropertyAccessExpression(node)) {
         if (isStyledObject(node.expression)) {
             return true;


### PR DESCRIPTION
display names would not show when we assigned components using withProps (using this implementation https://github.com/styled-components/styled-components/issues/630#issuecomment-317172454). This change works for the withProps wrapper in our code but I am unsure of whether the change could impact any internal functionality for the package.