### PR TITLE
Fix minification issues

### DIFF
--- a/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue36-extended.ts 1`] = `
+
+File: issue36-extended.ts
+Source code:
+
+  declare const styled: any;
+  
+  export const A = styled.div\`
+    border: \${'solid'} 10px;
+  \`
+  
+
+TypeScript before transform:
+
+  declare const styled: any;
+  export const A = styled.div \`\\n  border: \${"solid"} 10px;\\n\`;
+  
+
+TypeScript after transform:
+
+  declare const styled: any;
+  export const A = styled.div \`border:\${'solid'}10px;\`;
+  
+
+
+`;

--- a/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
@@ -38,7 +38,7 @@ TypeScript after transform:
 
   declare const styled: any;
   export const A = styled.div \`border:\${'solid'} 10px;\`;
-  styled.div \`border:\${'solid'}10px;border:solid10px;\`;
+  styled.div \`border:\${'solid'} 10px;border:solid 10px;\`;
   styled.div \`border:\${'solid'} 10px;border:\${'solid'} 10px;\`;
   
 

--- a/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
@@ -21,7 +21,7 @@ TypeScript before transform:
 TypeScript after transform:
 
   declare const styled: any;
-  export const A = styled.div \`border:\${'solid'}10px;\`;
+  export const A = styled.div \`border:\${'solid'} 10px;\`;
   
 
 

--- a/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification-only/issue36-extended.ts.baseline
@@ -11,17 +11,35 @@ Source code:
     border: \${'solid'} 10px;
   \`
   
+  styled.div\`
+    border: \${'solid'}// comment here
+  10px;
+    border: solid// comment here
+  10px;
+  \`
+  
+  styled.div\`
+    border: \${'solid'}/* comment here
+  */10px;
+    border: \${'solid'}/* comment here
+  */ 10px;
+  \`
+  
 
 TypeScript before transform:
 
   declare const styled: any;
   export const A = styled.div \`\\n  border: \${"solid"} 10px;\\n\`;
+  styled.div \`\\n  border: \${"solid"}// comment here\\n10px;\\n  border: solid// comment here\\n10px;\\n\`;
+  styled.div \`\\n  border: \${"solid"}/* comment here\\n*/10px;\\n  border: \${"solid"}/* comment here\\n*/ 10px;\\n\`;
   
 
 TypeScript after transform:
 
   declare const styled: any;
   export const A = styled.div \`border:\${'solid'} 10px;\`;
+  styled.div \`border:\${'solid'}10px;border:solid10px;\`;
+  styled.div \`border:\${'solid'} 10px;border:\${'solid'} 10px;\`;
   
 
 

--- a/src/__tests__/baselines/minification-only/issue36.tsx.baseline
+++ b/src/__tests__/baselines/minification-only/issue36.tsx.baseline
@@ -38,7 +38,7 @@ TypeScript after transform:
   declare const keyframes: any;
   declare const styled: any;
   const rotate360 = keyframes \`from{transform:rotate(0deg);}to{transform:rotate(360deg);}\`;
-  export const StyledDiv = styled.div \`width:100px;height:100px;background-color:greenyellow;animation:\${rotate360}2s linear infinite;\`;
+  export const StyledDiv = styled.div \`width:100px;height:100px;background-color:greenyellow;animation:\${rotate360} 2s linear infinite;\`;
   
 
 

--- a/src/__tests__/baselines/minification-only/issue36.tsx.baseline
+++ b/src/__tests__/baselines/minification-only/issue36.tsx.baseline
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue36.tsx 1`] = `
+
+File: issue36.tsx
+Source code:
+
+  declare const keyframes: any;
+  declare const styled: any;
+  
+  const rotate360 = keyframes\`
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  \`;
+  
+  export const StyledDiv = styled.div\`
+    width: 100px;
+    height: 100px;
+    background-color: greenyellow;
+    animation: \${rotate360} 2s linear infinite;
+  \`;
+  
+
+TypeScript before transform:
+
+  declare const keyframes: any;
+  declare const styled: any;
+  const rotate360 = keyframes \`\\n  from {\\n    transform: rotate(0deg);\\n  }\\n  to {\\n    transform: rotate(360deg);\\n  }\\n\`;
+  export const StyledDiv = styled.div \`\\n  width: 100px;\\n  height: 100px;\\n  background-color: greenyellow;\\n  animation: \${rotate360} 2s linear infinite;\\n\`;
+  
+
+TypeScript after transform:
+
+  declare const keyframes: any;
+  declare const styled: any;
+  const rotate360 = keyframes \`from{transform:rotate(0deg);}to{transform:rotate(360deg);}\`;
+  export const StyledDiv = styled.div \`width:100px;height:100px;background-color:greenyellow;animation:\${rotate360}2s linear infinite;\`;
+  
+
+
+`;

--- a/src/__tests__/baselines/minification-only/minify-css-to-use-without-transpilation.ts.baseline
+++ b/src/__tests__/baselines/minification-only/minify-css-to-use-without-transpilation.ts.baseline
@@ -65,7 +65,7 @@ TypeScript after transform:
   const SpecialCharacters = styled.div \`content:"  \${props => props.text}  ";color:red;\`;
   const Comment = styled.div \`width:100%;color:red;\`;
   const Parens = styled.div \`&:hover{color:blue;}color:red;\`;
-  const UrlComments = styled.div \`color:red; background:red;border:1px solid green;\`;
+  const UrlComments = styled.div \`color:red;background:red;border:1px solid green;\`;
   export {};
   
 

--- a/src/__tests__/baselines/minification-only/simple.ts.baseline
+++ b/src/__tests__/baselines/minification-only/simple.ts.baseline
@@ -158,7 +158,7 @@ TypeScript after transform:
   styled.div \`line one{line:two;}\`;
   // removes line comments at the end of lines of code
   // \`valid line with out comments\`
-  styled.div \`valid line without comments\`;
+  styled.div \`valid line with out comments\`;
   // preserves multi-line comments starting with /*!
   // \`this is a /*! dont ignore me please */ test\`
   styled.div \`this is a test\`;

--- a/src/__tests__/baselines/minification/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification/issue36-extended.ts.baseline
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue36-extended.ts 1`] = `
+
+File: issue36-extended.ts
+Source code:
+
+  declare const styled: any;
+  
+  export const A = styled.div\`
+    border: \${'solid'} 10px;
+  \`
+  
+
+TypeScript before transform:
+
+  declare const styled: any;
+  export const A = styled.div \`\\n  border: \${"solid"} 10px;\\n\`;
+  
+
+TypeScript after transform:
+
+  declare const styled: any;
+  export const A = styled.div.withConfig({ displayName: "A" }) \`border:\${'solid'}10px;\`;
+  
+
+
+`;

--- a/src/__tests__/baselines/minification/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification/issue36-extended.ts.baseline
@@ -21,7 +21,7 @@ TypeScript before transform:
 TypeScript after transform:
 
   declare const styled: any;
-  export const A = styled.div.withConfig({ displayName: "A" }) \`border:\${'solid'}10px;\`;
+  export const A = styled.div.withConfig({ displayName: "A" }) \`border:\${'solid'} 10px;\`;
   
 
 

--- a/src/__tests__/baselines/minification/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification/issue36-extended.ts.baseline
@@ -11,17 +11,35 @@ Source code:
     border: \${'solid'} 10px;
   \`
   
+  styled.div\`
+    border: \${'solid'}// comment here
+  10px;
+    border: solid// comment here
+  10px;
+  \`
+  
+  styled.div\`
+    border: \${'solid'}/* comment here
+  */10px;
+    border: \${'solid'}/* comment here
+  */ 10px;
+  \`
+  
 
 TypeScript before transform:
 
   declare const styled: any;
   export const A = styled.div \`\\n  border: \${"solid"} 10px;\\n\`;
+  styled.div \`\\n  border: \${"solid"}// comment here\\n10px;\\n  border: solid// comment here\\n10px;\\n\`;
+  styled.div \`\\n  border: \${"solid"}/* comment here\\n*/10px;\\n  border: \${"solid"}/* comment here\\n*/ 10px;\\n\`;
   
 
 TypeScript after transform:
 
   declare const styled: any;
   export const A = styled.div.withConfig({ displayName: "A" }) \`border:\${'solid'} 10px;\`;
+  styled.div \`border:\${'solid'}10px;border:solid10px;\`;
+  styled.div \`border:\${'solid'} 10px;border:\${'solid'} 10px;\`;
   
 
 

--- a/src/__tests__/baselines/minification/issue36-extended.ts.baseline
+++ b/src/__tests__/baselines/minification/issue36-extended.ts.baseline
@@ -38,7 +38,7 @@ TypeScript after transform:
 
   declare const styled: any;
   export const A = styled.div.withConfig({ displayName: "A" }) \`border:\${'solid'} 10px;\`;
-  styled.div \`border:\${'solid'}10px;border:solid10px;\`;
+  styled.div \`border:\${'solid'} 10px;border:solid 10px;\`;
   styled.div \`border:\${'solid'} 10px;border:\${'solid'} 10px;\`;
   
 

--- a/src/__tests__/baselines/minification/issue36.tsx.baseline
+++ b/src/__tests__/baselines/minification/issue36.tsx.baseline
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue36.tsx 1`] = `
+
+File: issue36.tsx
+Source code:
+
+  declare const keyframes: any;
+  declare const styled: any;
+  
+  const rotate360 = keyframes\`
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  \`;
+  
+  export const StyledDiv = styled.div\`
+    width: 100px;
+    height: 100px;
+    background-color: greenyellow;
+    animation: \${rotate360} 2s linear infinite;
+  \`;
+  
+
+TypeScript before transform:
+
+  declare const keyframes: any;
+  declare const styled: any;
+  const rotate360 = keyframes \`\\n  from {\\n    transform: rotate(0deg);\\n  }\\n  to {\\n    transform: rotate(360deg);\\n  }\\n\`;
+  export const StyledDiv = styled.div \`\\n  width: 100px;\\n  height: 100px;\\n  background-color: greenyellow;\\n  animation: \${rotate360} 2s linear infinite;\\n\`;
+  
+
+TypeScript after transform:
+
+  declare const keyframes: any;
+  declare const styled: any;
+  const rotate360 = keyframes \`from{transform:rotate(0deg);}to{transform:rotate(360deg);}\`;
+  export const StyledDiv = styled.div.withConfig({ displayName: "StyledDiv" }) \`width:100px;height:100px;background-color:greenyellow;animation:\${rotate360}2s linear infinite;\`;
+  
+
+
+`;

--- a/src/__tests__/baselines/minification/issue36.tsx.baseline
+++ b/src/__tests__/baselines/minification/issue36.tsx.baseline
@@ -38,7 +38,7 @@ TypeScript after transform:
   declare const keyframes: any;
   declare const styled: any;
   const rotate360 = keyframes \`from{transform:rotate(0deg);}to{transform:rotate(360deg);}\`;
-  export const StyledDiv = styled.div.withConfig({ displayName: "StyledDiv" }) \`width:100px;height:100px;background-color:greenyellow;animation:\${rotate360}2s linear infinite;\`;
+  export const StyledDiv = styled.div.withConfig({ displayName: "StyledDiv" }) \`width:100px;height:100px;background-color:greenyellow;animation:\${rotate360} 2s linear infinite;\`;
   
 
 

--- a/src/__tests__/baselines/minification/minify-css-to-use-without-transpilation.ts.baseline
+++ b/src/__tests__/baselines/minification/minify-css-to-use-without-transpilation.ts.baseline
@@ -65,7 +65,7 @@ TypeScript after transform:
   const SpecialCharacters = styled.div.withConfig({ displayName: "SpecialCharacters" }) \`content:"  \${props => props.text}  ";color:red;\`;
   const Comment = styled.div.withConfig({ displayName: "Comment" }) \`width:100%;color:red;\`;
   const Parens = styled.div.withConfig({ displayName: "Parens" }) \`&:hover{color:blue;}color:red;\`;
-  const UrlComments = styled.div.withConfig({ displayName: "UrlComments" }) \`color:red; background:red;border:1px solid green;\`;
+  const UrlComments = styled.div.withConfig({ displayName: "UrlComments" }) \`color:red;background:red;border:1px solid green;\`;
   export {};
   
 

--- a/src/__tests__/baselines/minification/simple.ts.baseline
+++ b/src/__tests__/baselines/minification/simple.ts.baseline
@@ -158,7 +158,7 @@ TypeScript after transform:
   styled.div \`line one{line:two;}\`;
   // removes line comments at the end of lines of code
   // \`valid line with out comments\`
-  styled.div \`valid line without comments\`;
+  styled.div \`valid line with out comments\`;
   // preserves multi-line comments starting with /*!
   // \`this is a /*! dont ignore me please */ test\`
   styled.div \`this is a test\`;

--- a/src/__tests__/fixtures/minification/issue36-extended.ts
+++ b/src/__tests__/fixtures/minification/issue36-extended.ts
@@ -1,0 +1,5 @@
+declare const styled: any;
+
+export const A = styled.div`
+  border: ${'solid'} 10px;
+`

--- a/src/__tests__/fixtures/minification/issue36-extended.ts
+++ b/src/__tests__/fixtures/minification/issue36-extended.ts
@@ -3,3 +3,17 @@ declare const styled: any;
 export const A = styled.div`
   border: ${'solid'} 10px;
 `
+
+styled.div`
+  border: ${'solid'}// comment here
+10px;
+  border: solid// comment here
+10px;
+`
+
+styled.div`
+  border: ${'solid'}/* comment here
+*/10px;
+  border: ${'solid'}/* comment here
+*/ 10px;
+`

--- a/src/__tests__/fixtures/minification/issue36.tsx
+++ b/src/__tests__/fixtures/minification/issue36.tsx
@@ -1,0 +1,18 @@
+declare const keyframes: any;
+declare const styled: any;
+
+const rotate360 = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const StyledDiv = styled.div`
+  width: 100px;
+  height: 100px;
+  background-color: greenyellow;
+  animation: ${rotate360} 2s linear infinite;
+`;


### PR DESCRIPTION
This PR fixes #36 

Example:
```ts
styled.div`
  border: ${'solid'} 2px;
`
```

Minified before:
```ts
styled.div`border:${'solid'}2px;` // would result in 'border:solid2px'
```

Minified after:
```ts
styled.div`border:${'solid'} 2px;` // would result in 'border:solid 2px'
```

Particularly these two commits show the diff:
- Fix 1: https://github.com/Igorbek/typescript-plugin-styled-components/pull/39/commits/0b7dfc4548f5e6bb42cbadc16bb4924e555f3a13
- Fix 2: https://github.com/Igorbek/typescript-plugin-styled-components/pull/39/commits/a8bee3fddd9d986befb80e12bdbe2c6f08aa6831