### PR TITLE
Remove .extend transformations as they've been removed from styled v4.

### DIFF
--- a/src/createTransformer.ts
+++ b/src/createTransformer.ts
@@ -17,24 +17,13 @@ import { minifyTemplate } from './minify';
  * Recognizes the following patterns:
  *
  * styled.tag
- * Component.extend
  * styled(Component)
  * styled('tag')
  * styledFunction.attrs(attributes)
 */
 function isStyledFunction(node: ts.Node, identifiers: CustomStyledIdentifiers): boolean {
     if (isPropertyAccessExpression(node)) {
-        if (isStyledObject(node.expression, identifiers)) {
-            return true;
-        }
-
-        if (node.name.text === 'extend'
-            && isValidComponent(node.expression)) {
-
-            return true;
-        }
-
-        return false;
+        return isStyledObject(node.expression, identifiers)
     }
 
     if (isCallExpression(node) && node.arguments.length === 1) {


### PR DESCRIPTION
`.extend` was removed from styled-components in v4 (styled-components/styled-components#1908), 

This PR removes support for it in this plugin so it no longer has to be maintained, fixing issues similar #33.

TODO
- [ ] Cleaning up tests (if maintainer will accept the change)

Fixes #48 