### PR TITLE
Remove deprecated `.extend` transformation pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- remove deprecated .extend transformation pattern (fix #48 in #152)
+
 ## [1.4.4]
 
 - bugfix in minification of tabs (fix #142 in #152)

--- a/src/__tests__/baselines/base/issue33.ts.baseline
+++ b/src/__tests__/baselines/base/issue33.ts.baseline
@@ -39,7 +39,7 @@ TypeScript after transform:
   declare const jQuery: any;
   declare const _: any;
   declare const Button: any;
-  const Button1 = Button.extend.withConfig({ displayName: "Button1" }) \` color: red \`;
+  const Button1 = Button.extend \` color: red \`;
   const Button2 = $.extend \` color: red \`;
   const Button3 = jQuery.extend \` color: red \`;
   const Button4 = _.extend \` color: red \`;

--- a/src/__tests__/baselines/base/sample1.ts.baseline
+++ b/src/__tests__/baselines/base/sample1.ts.baseline
@@ -78,13 +78,13 @@ TypeScript after transform:
   const OtherButton = styled(Button).withConfig({ displayName: "OtherButton" }) \`
     color: blue;
   \`;
-  const SuperButton = Button.extend.withConfig({ displayName: "SuperButton" }) \`
+  const SuperButton = Button.extend \`
     color: super;
   \`;
   export default styled.link \`
     color: black;
   \`;
-  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton" }) \`
+  export const SmallButton = Button.extend \`
     font-size: .7em;
   \`;
   const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton" }) \`

--- a/src/__tests__/baselines/base/style-objects.ts.baseline
+++ b/src/__tests__/baselines/base/style-objects.ts.baseline
@@ -78,13 +78,13 @@ TypeScript after transform:
   const OtherButton = styled(Button).withConfig({ displayName: "OtherButton" })({
       color: 'blue'
   });
-  const SuperButton = Button.extend.withConfig({ displayName: "SuperButton" })({
+  const SuperButton = Button.extend({
       color: 'super'
   });
   export default styled.link({
       color: 'black'
   });
-  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton" })({
+  export const SmallButton = Button.extend({
       fontSize: '.7em'
   });
   const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton" })({

--- a/src/__tests__/baselines/ssr/issue33.ts.baseline
+++ b/src/__tests__/baselines/ssr/issue33.ts.baseline
@@ -39,7 +39,7 @@ TypeScript after transform:
   declare const jQuery: any;
   declare const _: any;
   declare const Button: any;
-  const Button1 = Button.extend.withConfig({ displayName: "Button1", componentId: "sc-1iinolv" }) \` color: red \`;
+  const Button1 = Button.extend \` color: red \`;
   const Button2 = $.extend \` color: red \`;
   const Button3 = jQuery.extend \` color: red \`;
   const Button4 = _.extend \` color: red \`;

--- a/src/__tests__/baselines/ssr/sample1.ts.baseline
+++ b/src/__tests__/baselines/ssr/sample1.ts.baseline
@@ -78,16 +78,16 @@ TypeScript after transform:
   const OtherButton = styled(Button).withConfig({ displayName: "OtherButton", componentId: "sc-ce0fkl" }) \`
     color: blue;
   \`;
-  const SuperButton = Button.extend.withConfig({ displayName: "SuperButton", componentId: "sc-10xv1bi" }) \`
+  const SuperButton = Button.extend \`
     color: super;
   \`;
   export default styled.link \`
     color: black;
   \`;
-  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton", componentId: "sc-8sh5f7" }) \`
+  export const SmallButton = Button.extend \`
     font-size: .7em;
   \`;
-  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-v7haos" }) \`
+  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-13fgjrc" }) \`
     font-size: .1em;
   \`;
   

--- a/src/__tests__/baselines/ssr/style-objects.ts.baseline
+++ b/src/__tests__/baselines/ssr/style-objects.ts.baseline
@@ -78,16 +78,16 @@ TypeScript after transform:
   const OtherButton = styled(Button).withConfig({ displayName: "OtherButton", componentId: "sc-14ah7t" })({
       color: 'blue'
   });
-  const SuperButton = Button.extend.withConfig({ displayName: "SuperButton", componentId: "sc-1t5v351" })({
+  const SuperButton = Button.extend({
       color: 'super'
   });
   export default styled.link({
       color: 'black'
   });
-  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton", componentId: "sc-ftk9hu" })({
+  export const SmallButton = Button.extend({
       fontSize: '.7em'
   });
-  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-15rszef" })({
+  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-v7xcd0" })({
       fontSize: '.1em'
   });
   

--- a/src/createTransformer.ts
+++ b/src/createTransformer.ts
@@ -28,9 +28,7 @@ function isStyledFunction(node: ts.Node, identifiers: CustomStyledIdentifiers): 
             return true;
         }
 
-        if (node.name.text === 'extend'
-            && isValidComponent(node.expression)) {
-
+        if (isStyledExtendIdentifier(node.name.text, identifiers)) {
             return true;
         }
 
@@ -95,6 +93,10 @@ function isStyledCssIdentifier(name: string, { css = ['css'] }: CustomStyledIden
 
 function isStyledCreateGlobalStyleIdentifier(name: string, { createGlobalStyle = ['createGlobalStyle'] }: CustomStyledIdentifiers) {
     return createGlobalStyle.indexOf(name) >= 0;
+}
+
+function isStyledExtendIdentifier(name: string, { extend = [] }: CustomStyledIdentifiers) {
+    return extend.indexOf(name) >= 0;
 }
 
 function isMinifyableStyledFunction(node: ts.Node, identifiers: CustomStyledIdentifiers) {

--- a/src/models/Options.ts
+++ b/src/models/Options.ts
@@ -76,4 +76,11 @@ export interface CustomStyledIdentifiers {
      * @defaultValue `['createGlobalStyle']`
      */
     createGlobalStyle?: string[];
+
+    /**
+     * Identifiers of `extend` function.
+     * 
+     * @defaultValue `[]`
+     */
+     extend?: string[];
 }


### PR DESCRIPTION
This PR makes styled-components `.extend` pattern optional, since it has been deprecated in v4(styled-components/styled-components#1908).

Moreover, appending `.withConfig` to other extend methods might break unrelated code, i.e. https://github.com/Igorbek/typescript-plugin-styled-components/issues/33

Related to #47, #33 and #48 

From #48 
- [x] make extend identifier configurable like other identifiers;
- [x] set default value to an empty array;
- [x] add readme/release notes with breaking change information and instructions to re-enable by providing settings.