### PR TITLE
Fix incorrect minification of calc()

### DIFF
--- a/src/__tests__/baselines/minification-only/issue233.ts.baseline
+++ b/src/__tests__/baselines/minification-only/issue233.ts.baseline
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue233.ts 1`] = `
+
+File: issue233.ts
+Source code:
+
+  declare const styled: any;
+  
+  // repro from #233
+  const ValueCalc = styled.div\`
+    height: calc(var(--line-height) - 5px);
+    width: calc(100% - 5px);
+  \`;
+  
+  // another case from #233
+  styled.div\`--padding-button: calc(var(--padding-button-vertical) - 2px) calc(var(--padding-button-horizontal) - 2px);\`
+  
+  // a few more cases
+  styled.div\`
+   width: calc(   1%)
+   width: calc(   1%   + var(--a) - calc(2%))
+   width: calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))
+  \`
+  
+
+TypeScript before transform:
+
+  declare const styled: any;
+  // repro from #233
+  const ValueCalc = styled.div \`
+    height: calc(var(--line-height) - 5px);
+    width: calc(100% - 5px);
+  \`;
+  // another case from #233
+  styled.div \`--padding-button: calc(var(--padding-button-vertical) - 2px) calc(var(--padding-button-horizontal) - 2px);\`;
+  // a few more cases
+  styled.div \`
+   width: calc(   1%)
+   width: calc(   1%   + var(--a) - calc(2%))
+   width: calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))
+  \`;
+  
+
+TypeScript after transform:
+
+  declare const styled: any;
+  // repro from #233
+  const ValueCalc = styled.div \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  // another case from #233
+  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  // a few more cases
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  
+
+TypeScript after transpile module:
+
+  // repro from #233
+  const ValueCalc = styled.div \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  // another case from #233
+  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  // a few more cases
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  
+
+
+`;

--- a/src/__tests__/baselines/minification-only/issue233.ts.baseline
+++ b/src/__tests__/baselines/minification-only/issue233.ts.baseline
@@ -46,21 +46,21 @@ TypeScript after transform:
 
   declare const styled: any;
   // repro from #233
-  const ValueCalc = styled.div \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  const ValueCalc = styled.div \`height:calc(var(--line-height) - 5px);width:calc(100% - 5px);\`;
   // another case from #233
-  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  styled.div \`--padding-button:calc(var(--padding-button-vertical) - 2px)calc(var(--padding-button-horizontal) - 2px);\`;
   // a few more cases
-  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a) - calc(2%))width:calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))\`;
   
 
 TypeScript after transpile module:
 
   // repro from #233
-  const ValueCalc = styled.div \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  const ValueCalc = styled.div \`height:calc(var(--line-height) - 5px);width:calc(100% - 5px);\`;
   // another case from #233
-  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  styled.div \`--padding-button:calc(var(--padding-button-vertical) - 2px)calc(var(--padding-button-horizontal) - 2px);\`;
   // a few more cases
-  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a) - calc(2%))width:calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))\`;
   
 
 

--- a/src/__tests__/baselines/minification/issue233.ts.baseline
+++ b/src/__tests__/baselines/minification/issue233.ts.baseline
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue233.ts 1`] = `
+
+File: issue233.ts
+Source code:
+
+  declare const styled: any;
+  
+  // repro from #233
+  const ValueCalc = styled.div\`
+    height: calc(var(--line-height) - 5px);
+    width: calc(100% - 5px);
+  \`;
+  
+  // another case from #233
+  styled.div\`--padding-button: calc(var(--padding-button-vertical) - 2px) calc(var(--padding-button-horizontal) - 2px);\`
+  
+  // a few more cases
+  styled.div\`
+   width: calc(   1%)
+   width: calc(   1%   + var(--a) - calc(2%))
+   width: calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))
+  \`
+  
+
+TypeScript before transform:
+
+  declare const styled: any;
+  // repro from #233
+  const ValueCalc = styled.div \`
+    height: calc(var(--line-height) - 5px);
+    width: calc(100% - 5px);
+  \`;
+  // another case from #233
+  styled.div \`--padding-button: calc(var(--padding-button-vertical) - 2px) calc(var(--padding-button-horizontal) - 2px);\`;
+  // a few more cases
+  styled.div \`
+   width: calc(   1%)
+   width: calc(   1%   + var(--a) - calc(2%))
+   width: calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))
+  \`;
+  
+
+TypeScript after transform:
+
+  declare const styled: any;
+  // repro from #233
+  const ValueCalc = styled.div.withConfig({ displayName: "ValueCalc" }) \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  // another case from #233
+  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  // a few more cases
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  
+
+TypeScript after transpile module:
+
+  // repro from #233
+  const ValueCalc = styled.div.withConfig({ displayName: "ValueCalc" }) \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  // another case from #233
+  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  // a few more cases
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  
+
+
+`;

--- a/src/__tests__/baselines/minification/issue233.ts.baseline
+++ b/src/__tests__/baselines/minification/issue233.ts.baseline
@@ -46,21 +46,21 @@ TypeScript after transform:
 
   declare const styled: any;
   // repro from #233
-  const ValueCalc = styled.div.withConfig({ displayName: "ValueCalc" }) \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  const ValueCalc = styled.div.withConfig({ displayName: "ValueCalc" }) \`height:calc(var(--line-height) - 5px);width:calc(100% - 5px);\`;
   // another case from #233
-  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  styled.div \`--padding-button:calc(var(--padding-button-vertical) - 2px)calc(var(--padding-button-horizontal) - 2px);\`;
   // a few more cases
-  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a) - calc(2%))width:calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))\`;
   
 
 TypeScript after transpile module:
 
   // repro from #233
-  const ValueCalc = styled.div.withConfig({ displayName: "ValueCalc" }) \`height:calc(var(--line-height)- 5px);width:calc(100% - 5px);\`;
+  const ValueCalc = styled.div.withConfig({ displayName: "ValueCalc" }) \`height:calc(var(--line-height) - 5px);width:calc(100% - 5px);\`;
   // another case from #233
-  styled.div \`--padding-button:calc(var(--padding-button-vertical)- 2px) calc(var(--padding-button-horizontal)- 2px);\`;
+  styled.div \`--padding-button:calc(var(--padding-button-vertical) - 2px)calc(var(--padding-button-horizontal) - 2px);\`;
   // a few more cases
-  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a)- calc(2%)) width:calc(   1%   + var(--a)- calc(2%)+ calc( 1px + calc(1px + 2px)+ var(--a)))\`;
+  styled.div \`width:calc(   1%)width:calc(   1%   + var(--a) - calc(2%))width:calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))\`;
   
 
 

--- a/src/__tests__/fixtures/minification/issue233.ts
+++ b/src/__tests__/fixtures/minification/issue233.ts
@@ -1,0 +1,17 @@
+declare const styled: any;
+
+// repro from #233
+const ValueCalc = styled.div`
+  height: calc(var(--line-height) - 5px);
+  width: calc(100% - 5px);
+`;
+
+// another case from #233
+styled.div`--padding-button: calc(var(--padding-button-vertical) - 2px) calc(var(--padding-button-horizontal) - 2px);`
+
+// a few more cases
+styled.div`
+ width: calc(   1%)
+ width: calc(   1%   + var(--a) - calc(2%))
+ width: calc(   1%   + var(--a) - calc(2%) + calc( 1px + calc(1px + 2px) + var(--a)))
+`


### PR DESCRIPTION
Fixes #233 and supersedes #234.

Now with any open `(` in the CSS we count how many of them opened and do not minify until all closed with the corresponding `)`.